### PR TITLE
updates the werkzeug requirement to version 0.9.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ flask
 flask-wtf
 requests
 pymongo
-werkzeug==0.9.4
+werkzeug==0.9.6


### PR DESCRIPTION
Werkzeug < 0.9.6 has a bug when running on python 2.7.7.
See https://github.com/mitsuhiko/werkzeug/issues/537 for reference