### PR TITLE
no longer app.py, use run.py in the root

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,4 +16,4 @@ ADD ./local_settings.docker /opt/saltpad/saltpad/local_settings.py
 EXPOSE 5000
 WORKDIR /opt/saltpad/saltpad
 
-CMD ["/usr/bin/python","/opt/saltpad/saltpad/app.py"]
+CMD ["/usr/bin/python","/opt/saltpad/run.py"]


### PR DESCRIPTION
inveracity's comment here:
https://github.com/tinyclues/saltpad/issues/44

got me to realize the Dockerfile was out of date, when I made this change everything started working for me inside another docker project:
https://github.com/joshuacox/docker-salt

